### PR TITLE
Fixed the issue where creating the intake form from the app does not affect the database

### DIFF
--- a/src/pages/forms.jsx
+++ b/src/pages/forms.jsx
@@ -383,12 +383,12 @@ const Forms = () => {
     handleStatusOpen("Saving...", "info");
     childSchema
       .validate(childData, { abortEarly: false })
-      .then(() => {
-        const submitChildSuccess = handleSubmitChildInformation();
-        const submitMotherSuccess = handleSubmitMotherInformation();
-        const submitFatherSuccess = handleSubmitFatherInformation();
-        const submitKapatiduccess = handleSubmitKapatidInformation();
-        const submitFamilyInfoSuccess = handleSubmitFamilyInformation();
+      .then(async () => {
+        const submitChildSuccess = await handleSubmitChildInformation();
+        const submitMotherSuccess = await handleSubmitMotherInformation();
+        const submitFatherSuccess = await handleSubmitFatherInformation();
+        const submitKapatiduccess = await handleSubmitKapatidInformation();
+        const submitFamilyInfoSuccess = await handleSubmitFamilyInformation();
         if (
           submitChildSuccess &&
           submitMotherSuccess &&


### PR DESCRIPTION
The issue was the creation of the intake form was not done asynchronously. Thus, the form did not reach the database as it immediately redirected to the overview page.

This pull request can make the app wait for the server to change the database by making the function inside the `then()` of `childSchema` asynchronous, and adding `await` to each of the functions that handle the submission of the intake form.